### PR TITLE
Refactor fragment failure handling to not rely exclusively on status codes

### DIFF
--- a/src/moonarchive/downloaders/youtube.py
+++ b/src/moonarchive/downloaders/youtube.py
@@ -331,6 +331,8 @@ async def frag_iterator(
                 yield info
                 max_seq = new_max_seq
                 cur_seq += 1
+            # no download issues, so move on to the next iteration
+            continue
         except httpx.HTTPStatusError as exc:
             # this desperately needs refactoring...
             status_queue.put_nowait(
@@ -445,7 +447,7 @@ async def frag_iterator(
                 await asyncio.sleep(10)
         except (httpx.HTTPError, httpx.StreamError):
             # for everything else we just retry
-            continue
+            pass
 
 
 @dataclasses.dataclass

--- a/src/moonarchive/downloaders/youtube.py
+++ b/src/moonarchive/downloaders/youtube.py
@@ -280,7 +280,11 @@ async def frag_iterator(
                 selected_format.quality_label, selected_format.media_type.codec
             )
         )
-    status_queue.put_nowait(messages.StringMessage(f"{itag=} {timeout=}"))
+    status_queue.put_nowait(
+        messages.FormatSelectionMessage(
+            current_manifest_id, selector.major_type, selected_format
+        )
+    )
 
     client = httpx.AsyncClient(follow_redirects=True)
 
@@ -475,7 +479,11 @@ async def frag_iterator(
             preferred_format, *_ = selector.select(android_streaming_data.adaptive_formats)
             itag = preferred_format.itag
 
-            status_queue.put_nowait(messages.StringMessage(f"{itag=} {timeout=}"))
+            status_queue.put_nowait(
+                messages.FormatSelectionMessage(
+                    current_manifest_id, selector.major_type, preferred_format
+                )
+            )
 
 
 @dataclasses.dataclass

--- a/src/moonarchive/downloaders/youtube.py
+++ b/src/moonarchive/downloaders/youtube.py
@@ -358,14 +358,16 @@ async def frag_iterator(
                 # stream access expired? retrieve a fresh manifest
                 # the stream may have finished while we were mid-download, so don't check that here
                 # FIXME: we need to check playability_status instead of bailing
-                if not resp.streaming_data:
-                    return
-                android_streaming_data = await _get_streaming_data_from_android(video_id)
-                if not android_streaming_data:
-                    return
-                manifest = await android_streaming_data.get_dash_manifest()
-                if not manifest:
-                    return
+                new_android_streaming_data = await _get_streaming_data_from_android(video_id)
+                if not new_android_streaming_data:
+                    check_stream_status = True
+                else:
+                    android_streaming_data = android_streaming_data
+                    new_manifest = await android_streaming_data.get_dash_manifest()
+                    if not new_manifest:
+                        check_stream_status = True
+                    else:
+                        manifest = new_manifest
             elif exc.response.status_code in (404, 500, 503):
                 check_stream_status = True
             elif exc.response.status_code == 401:

--- a/src/moonarchive/downloaders/youtube.py
+++ b/src/moonarchive/downloaders/youtube.py
@@ -296,7 +296,13 @@ async def frag_iterator(
 
     num_parallel_downloads = num_parallel_downloads_ctx.get()
 
+    reqs: list[tuple[int, asyncio.Task]] = []
+
     while True:
+        # clear any outstanding requests from the previous iteration
+        for req_seq, req_task in reqs:
+            req_task.cancel()
+
         url = manifest.format_urls[itag]
 
         try:

--- a/src/moonarchive/downloaders/youtube.py
+++ b/src/moonarchive/downloaders/youtube.py
@@ -374,6 +374,17 @@ async def frag_iterator(
             elif exc.response.status_code in (404, 500, 503):
                 check_stream_status = True
             elif exc.response.status_code == 401:
+                status_queue.put_nowait(
+                    messages.StringMessage(f"Received HTTP 401 error {cur_seq=}, retrying")
+                )
+                await asyncio.sleep(10)
+                continue
+            else:
+                status_queue.put_nowait(
+                    messages.StringMessage(
+                        f"Unhandled HTTP code {exc.response.status_code}, retrying"
+                    )
+                )
                 await asyncio.sleep(10)
                 continue
             if check_stream_status:

--- a/src/moonarchive/models/messages.py
+++ b/src/moonarchive/models/messages.py
@@ -6,6 +6,7 @@ import pathlib
 import msgspec
 
 from .ffmpeg import FFMPEGProgress
+from .youtube_player import YTPlayerAdaptiveFormats, YTPlayerMediaType
 
 
 class BaseMessage(msgspec.Struct, tag=True):
@@ -40,6 +41,12 @@ class StreamInfoMessage(BaseMessage, tag="stream-info"):
 class StreamVideoFormatMessage(BaseMessage, tag="stream-video-format"):
     quality_label: str
     codec: str | None
+
+
+class FormatSelectionMessage(BaseMessage, tag="format-selection"):
+    manifest_id: str
+    major_type: YTPlayerMediaType
+    format: YTPlayerAdaptiveFormats
 
 
 class ExtractingPlayerResponseMessage(BaseMessage, tag="extracting-player-response"):


### PR DESCRIPTION
Fixes #3.

Still needs to be tested for regressions and cleaned up of diagnostic messages.