### PR TITLE
Switch pyav package for av

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "colorama ~= 0.4",
     "httpx ~= 0.27",
     "msgspec ~= 0.18",
-    "pyav ~= 12.0",
+    "av ~= 14.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
`pyav` is no longer available from PyPI, reported on 2025-06-10 [here](https://redirect.github.com/PyAV-Org/PyAV/issues/1916).

Per https://github.com/PyAV-Org/PyAV/discussions/1827 it was a legitimate build released separately from `av`, so we now have to migrate.

Will merge the branch in once I've tested and confirmed no issues.